### PR TITLE
Fixes to complex matrix extraction from Gaussian

### DIFF
--- a/src/mqc_algebra.F03
+++ b/src/mqc_algebra.F03
@@ -3632,7 +3632,7 @@
             do i = 1,A%NRow
               do j = 1,i
                 k = k+1
-                AC_Symm(k) = A%matC(i,j)
+                AC_Symm(k) = A%matC(j,i)
               endDo
             endDo
             call ZHPEV('V','U',A%NRow,AC_Symm,A_EVals,AC_EVecs,A%NRow,TempC_Vector,Temp_Vector,IError)
@@ -7400,10 +7400,10 @@
 !     to full packing.
 !
 !     Options for this subroutine are:
-!       'symmetric'      Test if matrix is symmetric
-!       'antisymmetric'  Test if matrix is antisymmetric
-!       'hermitian'      Test if matrix is hermitian
-!       'antihermitian'  Test if matrix is antihermitian
+!       'symmetric'      Unpack as if matrix is symmetric
+!       'antisymmetric'  Unpack as if matrix is antisymmetric
+!       'hermitian'      Unpack as if matrix is hermitian
+!       'antihermitian'  Unpack as if matrix is antihermitian
 !
 !     L. M. Thompson, 2016, 2018.
 !
@@ -9348,8 +9348,8 @@
       character(len=1)::method
       character(len=64)::StorFlag,TypeFlag
       real(kind=real64),dimension(:),allocatable::work
-      real(kind=real64)::dlange
-      Complex(Kind=real64)::zlange
+      real(kind=real64)::dlange,zlange
+!      Complex(Kind=real64)::zlange
       real(kind=real64),dimension(:,:),allocatable::temp
       Complex(Kind=real64),dimension(:,:),allocatable::tempC
       Type(MQC_Scalar)::norm

--- a/src/mqc_est.F03
+++ b/src/mqc_est.F03
@@ -184,7 +184,7 @@
         Module Procedure MQC_Integral_Conjugate_Transpose
       End Interface
 !
-      Interface Contract
+      Interface Contraction
         Module Procedure mqc_scf_integral_contraction
         Module Procedure mqc_eri_integral_contraction
       End Interface
@@ -2247,7 +2247,7 @@
 !     the input matrix would be reordered such that the off diagonal blocks are zero. I.e.
 !     the alpha columns contain the 1st, 3rd, 5th ... lowest energy orbitals and the beta
 !     columns contain the 2nd, 4th, 6th ... lowest energy orbitals. The first 0.5*(N_elec)+S 
-!     columns of the alpha block and the first 0.5*(N_elec)+S columns of the beta block are 
+!     columns of the alpha block and the first 0.5*(N_elec)-S columns of the beta block are 
 !     occupied.
 !
 !     L. M. Thompson, 2017.
@@ -2712,7 +2712,7 @@
       end do
 !
       if(integral%array_type.eq.'space') call mqc_integral_allocate(output,'contraction','space',alpha)
-      if(integral%array_type.eq.'spin') call mqc_integral_allocate(output,'contraction','spin',alpha,beta)
+      if(integral%array_type.eq.'spin') call mqc_integral_allocate(output,'contractin','spin',alpha,beta)
       if(integral%array_type.eq.'general') call mqc_integral_allocate(output,'contraction','general',alpha,beta,alphaBeta,betaAlpha)
 !
       end function mqc_eri_integral_contraction

--- a/src/mqc_gaussian.f03
+++ b/src/mqc_gaussian.f03
@@ -2725,7 +2725,6 @@
           call mqc_integral_allocate(est_wavefunction%density_matrix,'density','general', &
             tmpMatrixAlpha,tmpMatrixBeta,tmpMatrixAlphaBeta,tmpMatrixBetaAlpha)
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
-          call tmpMatrixAlpha%print(6,'LMT tmpMatrixAlpha')
           if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
             call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
             tmpMatrixAlpha = transpose(tmpMatrixAlpha)

--- a/src/mqc_gaussian.f03
+++ b/src/mqc_gaussian.f03
@@ -2413,18 +2413,30 @@
       case('core hamiltonian')
         if(fileinfo%isRestricted()) then
           call fileInfo%getArray('CORE HAMILTONIAN ALPHA',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_integral,'core hamiltonian','space',tmpMatrixAlpha)
         elseIf(fileinfo%isUnrestricted()) then
           call fileInfo%getArray('CORE HAMILTONIAN ALPHA',tmpMatrixAlpha)
           call fileInfo%getArray('CORE HAMILTONIAN BETA',tmpMatrixBeta)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
-          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
+          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) then
+            call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+            tmpMatrixBeta = transpose(tmpMatrixBeta)
+          endIf
           call mqc_integral_allocate(est_integral,'core hamiltonian','spin',tmpMatrixAlpha, &
             tmpMatrixBeta)
         elseIf(fileinfo%isGeneral()) then
           call fileInfo%getArray('CORE HAMILTONIAN ALPHA',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           nBasis = fileInfo%getVal('nBasis')
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
@@ -2442,18 +2454,30 @@
       case('fock')
         if(fileinfo%isRestricted()) then
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_integral,'fock','space',tmpMatrixAlpha)
         elseIf(fileinfo%isUnrestricted()) then
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
           call fileInfo%getArray('BETA FOCK MATRIX',tmpMatrixBeta)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
-          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
+          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) then
+            call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+            tmpMatrixBeta = transpose(tmpMatrixBeta)
+          endIf
           call mqc_integral_allocate(est_integral,'fock','spin',tmpMatrixAlpha, &
             tmpMatrixBeta)
         elseIf(fileinfo%isGeneral()) then
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           nBasis = fileInfo%getVal('nBasis')
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
@@ -2471,18 +2495,30 @@
       case('density')
         if(fileinfo%isRestricted()) then
           call fileInfo%getArray('ALPHA SCF DENSITY MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_integral,'density','space',tmpMatrixAlpha)
         elseIf(fileinfo%isUnrestricted()) then
           call fileInfo%getArray('ALPHA SCF DENSITY MATRIX',tmpMatrixAlpha)
           call fileInfo%getArray('BETA SCF DENSITY MATRIX',tmpMatrixBeta)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
-          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
+          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) then
+            call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+            tmpMatrixBeta = transpose(tmpMatrixBeta)
+          endIf
           call mqc_integral_allocate(est_integral,'density','spin',tmpMatrixAlpha, &
             tmpMatrixBeta)
         elseIf(fileinfo%isGeneral()) then
           call fileInfo%getArray('ALPHA SCF DENSITY MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           nBasis = fileInfo%getVal('nBasis')
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
@@ -2500,16 +2536,25 @@
       case('overlap')
         if(fileinfo%isRestricted()) then
           call fileInfo%getArray('OVERLAP',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_integral,'overlap','space',tmpMatrixAlpha)
         elseIf(fileinfo%isUnrestricted()) then
           call fileInfo%getArray('OVERLAP',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_integral,'overlap','spin',tmpMatrixAlpha, &
             tmpMatrixAlpha)
         elseIf(fileinfo%isGeneral()) then
           call fileInfo%getArray('OVERLAP',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           nBasis = fileInfo%getVal('nBasis')
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
@@ -2527,11 +2572,17 @@
       case('wavefunction')
         if(fileinfo%isRestricted()) then
           call fileInfo%getArray('OVERLAP',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_wavefunction%overlap_matrix,'overlap','space', &
             tmpMatrixAlpha)
           call fileInfo%getArray('CORE HAMILTONIAN ALPHA',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_wavefunction%core_hamiltonian,'core hamiltonian','space', &
             tmpMatrixAlpha)
           call fileInfo%getArray('ALPHA ORBITAL ENERGIES',vectorOut=tmpVectorAlpha)
@@ -2541,11 +2592,17 @@
           call mqc_integral_allocate(est_wavefunction%mo_coefficients,'mo coefficients','space', &
             tmpMatrixAlpha)
           call fileInfo%getArray('ALPHA SCF DENSITY MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_wavefunction%density_matrix,'density','space', &
             tmpMatrixAlpha)
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_wavefunction%fock_matrix,'fock','space',tmpMatrixAlpha)
           est_wavefunction%nBasis = fileInfo%getVal('nBasis')
           est_wavefunction%nAlpha = fileInfo%getVal('nAlpha')
@@ -2556,13 +2613,22 @@
           call mqc_gaussian_ICGU(fileInfo%ICGU,est_wavefunction%wf_type,est_wavefunction%wf_complex)
         elseIf(fileinfo%isUnrestricted()) then
           call fileInfo%getArray('OVERLAP',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_integral_allocate(est_wavefunction%overlap_matrix,'overlap','spin', &
             tmpMatrixAlpha,tmpMatrixAlpha)
           call fileInfo%getArray('CORE HAMILTONIAN ALPHA',tmpMatrixAlpha)
           call fileInfo%getArray('CORE HAMILTONIAN BETA',tmpMatrixBeta)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
-          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
+          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) then
+            call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+            tmpMatrixBeta = transpose(tmpMatrixBeta)
+          endIf
           call mqc_integral_allocate(est_wavefunction%core_hamiltonian,'core hamiltonian','spin', &
             tmpMatrixAlpha,tmpMatrixBeta)
           call fileInfo%getArray('ALPHA ORBITAL ENERGIES',vectorOut=tmpVectorAlpha)
@@ -2575,14 +2641,26 @@
             tmpMatrixAlpha,tmpMatrixBeta)
           call fileInfo%getArray('ALPHA SCF DENSITY MATRIX',tmpMatrixAlpha)
           call fileInfo%getArray('BETA SCF DENSITY MATRIX',tmpMatrixBeta)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
-          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
+          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) then
+            call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+            tmpMatrixBeta = transpose(tmpMatrixBeta)
+          endIf
           call mqc_integral_allocate(est_wavefunction%density_matrix,'density','spin', &
             tmpMatrixAlpha,tmpMatrixBeta)
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
           call fileInfo%getArray('BETA FOCK MATRIX',tmpMatrixBeta)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
-          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
+          if(MQC_Matrix_HaveComplex(tmpMatrixBeta)) then
+            call mqc_matrix_symm2full(tmpMatrixBeta,'hermitian')
+            tmpMatrixBeta = transpose(tmpMatrixBeta)
+          endIf
           call mqc_integral_allocate(est_wavefunction%fock_matrix,'fock','spin',tmpMatrixAlpha, &
             tmpMatrixBeta)
           est_wavefunction%nBasis = fileInfo%getVal('nBasis')
@@ -2594,7 +2672,10 @@
           call mqc_gaussian_ICGU(fileInfo%ICGU,est_wavefunction%wf_type,est_wavefunction%wf_complex)
         elseIf(fileinfo%isGeneral()) then
           call fileInfo%getArray('OVERLAP',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           nBasis = fileInfo%getVal('nBasis')
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
@@ -2604,7 +2685,10 @@
           call mqc_integral_allocate(est_wavefunction%overlap_matrix,'overlap','general', &
             tmpMatrixAlpha,tmpMatrixBeta,tmpMatrixAlphaBeta,tmpMatrixBetaAlpha)
           call fileInfo%getArray('CORE HAMILTONIAN ALPHA',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
           tmpMatrixBetaAlpha = tmpMatrixAlpha%mat([1,nBasis],[nBasis+1,-1])
@@ -2628,7 +2712,10 @@
           call mqc_integral_allocate(est_wavefunction%mo_coefficients,'mo_coefficients','general', &
             tmpMatrixAlpha,tmpMatrixBeta,tmpMatrixAlphaBeta,tmpMatrixBetaAlpha)
           call fileInfo%getArray('ALPHA SCF DENSITY MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
           tmpMatrixBetaAlpha = tmpMatrixAlpha%mat([1,nBasis],[nBasis+1,-1])
@@ -2638,7 +2725,11 @@
           call mqc_integral_allocate(est_wavefunction%density_matrix,'density','general', &
             tmpMatrixAlpha,tmpMatrixBeta,tmpMatrixAlphaBeta,tmpMatrixBetaAlpha)
           call fileInfo%getArray('ALPHA FOCK MATRIX',tmpMatrixAlpha)
-          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+          call tmpMatrixAlpha%print(6,'LMT tmpMatrixAlpha')
+          if(MQC_Matrix_HaveComplex(tmpMatrixAlpha)) then
+            call mqc_matrix_symm2full(tmpMatrixAlpha,'hermitian')
+            tmpMatrixAlpha = transpose(tmpMatrixAlpha)
+          endIf
           call mqc_matrix_spinBlockGHF(tmpMatrixAlpha)
           tmpMatrixBeta = tmpMatrixAlpha%mat([nBasis+1,-1],[nBasis+1,-1])
           tmpMatrixBetaAlpha = tmpMatrixAlpha%mat([1,nBasis],[nBasis+1,-1])


### PR DESCRIPTION

Changed complex Gaussian matrix extraction as these are column ordered on the matrix file, rather than row ordered as previously assumed. Note that
rdmat prints the upper triangular part as a lower triangular matrix.
Completed a few other debugging tasks.