### PR TITLE
Bug fixes

### DIFF
--- a/examples/diishf/OUTPUT/out
+++ b/examples/diishf/OUTPUT/out
@@ -5,11 +5,11 @@ Finished with tests designed to fail
 -------------
 MatFile test
 -------------
- 
+
  Hartree-Fock Density Matrix and Energy Calculator
- 
+
  L. M. Thompson 2018
- 
+
  
  nBasis =             17
  
@@ -83769,7 +83769,7 @@ Complex   =          F
      H      -0.504403     -0.873651     -0.356666
      H      -0.504403      0.873651     -0.356667
  -------------------------------------------------
- Nuclear Repulsion Energy (au) =    11.289257771617
+ Nuclear Repulsion Energy (au) =      11.289258
  Initial density matrix
  
    This is a diagonal matrix, so only diagonal elements are printed

--- a/examples/fullci/OUTPUT/out
+++ b/examples/fullci/OUTPUT/out
@@ -5,11 +5,11 @@ Finished with tests designed to fail
 -------------
 MatFile test
 -------------
- 
+
  Full Configuration Interaction Energy Calculator
- 
+
  L. M. Thompson 2016
- 
+
  
  nBasis =              2
  
@@ -123,7 +123,7 @@ Complex   =          F
  (  2,  2|  2,  1) =      0.00002300
  (  2,  2|  2,  2) =      0.77460594
  found UHF wavefunction
- Nuclear Repulsion Energy (au) =     0.105835442184
+ Nuclear Repulsion Energy (au) =       0.105835
 Alpha Strings
        1                                                                10
        2                                                                 1

--- a/examples/hartreefock/OUTPUT/out
+++ b/examples/hartreefock/OUTPUT/out
@@ -5,11 +5,11 @@ Finished with tests designed to fail
 -------------
 MatFile test
 -------------
- 
+
  Hartree-Fock Density Matrix and Energy Calculator
- 
+
  L. M. Thompson 2018
- 
+
  
  nBasis =              2
  
@@ -130,7 +130,7 @@ Complex   =          F
      H       0.000000      0.000000      0.000000
      H       0.000000      0.000000      4.999999
  -------------------------------------------------
- Nuclear Repulsion Energy (au) =     0.105835442184
+ Nuclear Repulsion Energy (au) =       0.105835
  Initial density matrix
  
                   1             2
@@ -199,8 +199,8 @@ Iteration:   1
                   1             2
        1      0.499946      0.499946
        2      0.499946      0.499946
- Energy =    -1.039196643399
- Convergence on density matrix =     1.414061079173
+ Energy =      -1.039197
+ Convergence on density matrix =       1.414061
 Iteration:   2
  G(P)
  Alpha Array
@@ -267,5 +267,5 @@ Iteration:   2
                   1             2
        1      0.499946      0.499946
        2      0.499946      0.499946
- Energy =    -0.599024872991
- Convergence on density matrix =     0.000000000000
+ Energy =      -0.599025
+ Convergence on density matrix =       0.000000

--- a/src/mqc_algebra.F03
+++ b/src/mqc_algebra.F03
@@ -137,9 +137,9 @@
 !>      \brief <b> Returns the maximum value in the MQC_Vector</b>
         Procedure, Public::maxval => MQC_Vector_MaxVal
 !>      \brief <b> Returns the minimum value in the MQC_Vector</b>
-        Procedure, Public::minval => MQC_Vector_MinLoc
+        Procedure, Public::minval => MQC_Vector_MinVal
 !>      \brief <b> Returns the location of the maximum value in the MQC_Vector</b>
-        Procedure, Public::maxloc => MQC_Vector_MaxVal
+        Procedure, Public::maxloc => MQC_Vector_MaxLoc
 !>      \brief <b> Returns the location of the minimum value in the MQC_Vector</b>
         Procedure, Public::minloc => MQC_Vector_MinLoc
 !>      \brief <b> Returns the indices of the MQC_Vector sorted from low to high</b>
@@ -1439,6 +1439,12 @@
 !>        = .True.:  print blank line below output
 !>        = .False.: do not print blank line below output.
 !>    \endverbatim
+!>
+!>    \param[in] FormatStr
+!>    \verbatim
+!>        FormatStr is Character(Len=*),Optional
+!>        Formatting statement for printing.
+!>    \endverbatim
 !
 !     Authors:
 !     ========
@@ -1446,7 +1452,7 @@
 !>    \date 2016
 !
       Subroutine MQC_Print_Scalar_Algebra1(Scalar,IOut,Header,Blank_At_Top, &
-        Blank_At_Bottom)
+        Blank_At_Bottom,FormatStr)
 !
 !     Variable Declarations.
       Implicit None
@@ -1454,26 +1460,44 @@
       Class(MQC_Scalar),Intent(In)::Scalar
       Character(Len=*),Intent(In)::Header
       Logical,Intent(In),Optional::Blank_At_Top,Blank_At_Bottom
+      Character(Len=*),Intent(In),Optional::FormatStr
+      Character(Len=256)::FormatLine
 !
  1001 Format(1x,A,1x,'=',1x,I14)
-! 1002 Format(1x,A,1x,'=',1x,F14.6)
- 1002 Format(1x,A,1x,'=',1x,F18.12)
+ 1002 Format(1x,A,1x,'=',1x,F14.6)
  1003 Format(1x,A,1x,'=',1x,F14.6,SP,F14.6,"i")
  1020 Format( " " )
 !
       If(PRESENT(Blank_At_Top)) then
         If(Blank_At_Top) Write(IOut,1020)
       EndIf
+
       If(Scalar%Data_type.eq.'Integer') then
-        Write(IOut,1001) TRIM(Header), Scalar%ScaI
+        If(present(FormatStr)) then
+          FormatLine = '(1x,A,1x,"=",1x,'//trim(FormatStr)//')'
+          Write(IOut,trim(FormatLine)) TRIM(Header), Scalar%ScaI
+        else
+          Write(IOut,1001) TRIM(Header), Scalar%ScaI
+        endIf
       ElseIf(Scalar%Data_type.eq.'Real') then
-        Write(IOut,1002) TRIM(Header), Scalar%ScaR
+        If(present(FormatStr)) then
+          FormatLine = '(1x,A,1x,"=",1x,'//trim(FormatStr)//')'
+          Write(IOut,trim(FormatLine)) TRIM(Header), Scalar%ScaR
+        else
+          Write(IOut,1002) TRIM(Header), Scalar%ScaR
+        endIf
       ElseIf(Scalar%Data_type.eq.'Complex') then
-        Write(IOut,1003) TRIM(Header), Scalar%ScaC
+        If(present(FormatStr)) then
+          FormatLine = '(1x,A,1x,"=",1x,'//trim(FormatStr)//',SP,'//trim(FormatStr)//',"i")'
+          Write(IOut,trim(FormatLine)) TRIM(Header), Scalar%ScaC
+        else
+          Write(IOut,1003) TRIM(Header), Scalar%ScaC
+        endIf
       Else
         Call MQC_Error_A('Scalar type unspecified in MQC_Print_Scalar_Algebra1', 6, &
              'Scalar%Data_type', Scalar%Data_type )
       EndIf
+
       If(PRESENT(Blank_At_Bottom)) then
         If(Blank_At_Bottom) Write(IOut,1020)
       EndIf
@@ -13984,9 +14008,9 @@
 !>        only required when taking hash of a rank-4 tensor.
 !>    \endverbatim
 !>    
-!>    \param[in] Order
+!>    \param[in] OrderIn
 !>    \verbatim
-!>        Order is Character(Len=*),optional
+!>        OrderIn is Character(Len=*),optional
 !>        The symmetry order for rank-4 tensors. Options are:
 !>        = '8-fold':  8-fold symmetry (default)
 !>        = '4-fold':  4-fold symmetry 
@@ -24250,7 +24274,16 @@
 !>    \param[in] A 
 !>    \verbatim
 !>        A is Class(MQC_Matrix)
-!>        The MQC matrix to psuedoinvert
+!>        The MQC matrix to psuedoinvert.
+!>    \endverbatim
+!>
+!>    \param[in] tol
+!>    \verbatim
+!>        Tol is Class(*),Optional
+!>        Tolerance used for zero threshold. The default value is 
+!>        eps*max(size(A,1),size(A,2))*max(SMat) suggested in
+!>        Klimczak, M.; Cecot, W. Math. Probl. Eng. 2019, 2019(3), 
+!>        5060397. 
 !>    \endverbatim
 !
 !     Authors:
@@ -24285,7 +24318,7 @@
           call mqc_error('Tolerance type not defined in MQC_Matrix_MPInv')
         end select
       else
-        thresh = 1.0e-15*evals%maxval()
+        thresh = evals%maxval()*epsilon(1.0e0)*max(size(A,1),size(A,2))
       endif
       Zero = 0.0e0
 

--- a/src/mqc_algebra.F03
+++ b/src/mqc_algebra.F03
@@ -203,7 +203,7 @@
 !>      \brief <b> Returns the trace of the MQC Matrix</b>
         Procedure, Public::trace => mqc_matrix_trace
 !>      \brief <b> Returns a vector of diagonal elements of the MQC Matrix</b>
-        Procedure, Public::pinv => mqc_matrix_MRInv
+        Procedure, Public::pinv => mqc_matrix_MPInv
 !>      \brief <b> Returns a vector of diagonal elements of the MQC Matrix</b>
         Procedure, Public::diagonal => mqc_matrix_diagonal_elements
 !>      \brief <b> Returns the root mean square deviation and maximum
@@ -5298,7 +5298,7 @@
       Implicit None
       Type(MQC_Scalar),Intent(In)::ScalarIn
       Type(MQC_Scalar)::ScalarOut
-      Real::Zero=0.0d0
+      Real(kind=real64)::Zero=0.0d0
 !
       ScalarOut = zero
       If(ScalarIn%Data_Type.eq.'Complex') ScalarOut = aimag(ScalarIn%ScaC)
@@ -24258,7 +24258,7 @@
 !>    \author L. M. Thompson
 !>    \date 2020
 !
-      Function MQC_Matrix_MRInv(A) Result(PInv)
+      Function MQC_Matrix_MPInv(A,tol) Result(PInv)
 !
       Implicit None
       Class(MQC_Matrix)::A
@@ -24267,12 +24267,28 @@
       Type(MQC_Vector)::EVals
       Type(MQC_Matrix)::PInv
       Type(MQC_Scalar)::Thresh,Zero
+      class(*),optional::tol
       Integer(kind=int64)::I
 !
-      Thresh = 1.0e-14
-      Zero = 0.0e0
       call A%SVD(EVals,EUVecs,EVVecs)
-      call EVals%diag(SMat)
+      if(present(tol)) then
+        select type (tol)
+        type is (integer)
+          thresh = tol
+        type is (real)
+          thresh = tol
+        type is (complex)
+          thresh = tol
+        type is (mqc_scalar)
+          thresh = tol
+        class default
+          call mqc_error('Tolerance type not defined in MQC_Matrix_MPInv')
+        end select
+      else
+        thresh = 1.0e-15*evals%maxval()
+      endif
+      Zero = 0.0e0
+
       Do I = 1, Size(EVals)
         If(EVals%at(I).gt.Thresh) then
           call EVals%put(1.0/EVals%at(I),I)
@@ -24284,7 +24300,7 @@
       PInv = matmul(matmul(dagger(EVVecs),SMat),dagger(EUVecs))
 !      
       Return
-      End Function MQC_Matrix_MRInv
+      End Function MQC_Matrix_MPInv
 !
 !
 !     PROCEDURE MQC_Matrix_Sum

--- a/src/mqc_est.F03
+++ b/src/mqc_est.F03
@@ -2495,8 +2495,8 @@
             j = ip - i*(i-1)/2
             l = kp - k*(k-1)/2
 
-            aaaaLoc(symIndexHash(i,j,k,l)) = twoERIs%at(i,l,k,j) - &
-              twoERIs%at(i,k,l,j)
+            aaaaLoc(symIndexHash(i,j,k,l)) = twoERIs%at(i,k,l,j) - &
+              twoERIs%at(i,l,k,j)
             if(ip.eq.kp) aaaaLoc(symIndexHash(i,j,k,l)) = &
               0.5*aaaaLoc(symIndexHash(i,j,k,l))
 
@@ -7155,6 +7155,8 @@
           flag = flag + 40000
         endIf
       endIf
+      
+      if(debug) write(6,'(A,1x,I5)') 'Option flag:',flag
 
       nBasis = integral%blockSize('alpha')
       ntt = (nBasis*(nBasis+1))/2
@@ -7468,7 +7470,7 @@
           if (m.ne.n) then
             if (doAhrm.or.mod(flag,10).eq.2.or.mod(flag,100)/10.eq.1) then
               if(mod(flag,1000)/100.eq.1) then
-                raf3 = eris(1)%at(k,n,m,l) - eris(1)%at(k,m,n,l)
+                raf3 = eris(1)%at(k,m,n,l) - eris(1)%at(k,n,m,l) 
                 if(kp.eq.mp) raf3 = 0.5*raf3 
               elseIf(mod(flag,10000)/1000.eq.4) then
                 raf3 = eris(2)%at(k,l,m,n) 
@@ -7503,17 +7505,17 @@
             if(m.ne.n.and.mod(flag,100)/10.eq.1) then
               if(abs(raf3).gt.zero) then
                 if(abs(aaHCden(symIndexHash(m,n))).gt.zero) &
-                  aaHCfoc(symIndexHash(k,l)) = aaHCfoc(symIndexHash(k,l)) + &
+                  aaHCfoc(symIndexHash(k,l)) = aaHCfoc(symIndexHash(k,l)) - &
                   raf3*aaHCden(symIndexHash(m,n))
                 if(abs(aaHCden(symIndexHash(k,l))).gt.zero) &
-                  aaHCfoc(symIndexHash(m,n)) = aaHCfoc(symIndexHash(m,n)) + &
+                  aaHCfoc(symIndexHash(m,n)) = aaHCfoc(symIndexHash(m,n)) - &
                   raf3*aaHCden(symIndexHash(k,l))
                 if(mod(flag,10).gt.0) then
                   if(abs(bbHCden(symIndexHash(m,n))).gt.zero) &
-                    bbHCfoc(symIndexHash(k,l)) = bbHCfoc(symIndexHash(k,l)) + &
+                    bbHCfoc(symIndexHash(k,l)) = bbHCfoc(symIndexHash(k,l)) - &
                     raf3*bbHCden(symIndexHash(m,n))
                   if(abs(bbHCden(symIndexHash(k,l))).gt.zero) &
-                    bbHCfoc(symIndexHash(m,n)) = bbHCfoc(symIndexHash(m,n)) + &
+                    bbHCfoc(symIndexHash(m,n)) = bbHCfoc(symIndexHash(m,n)) - &
                     raf3*bbHCden(symIndexHash(k,l))
                 endIf
               endIf
@@ -7528,18 +7530,18 @@
                 raf2*abHHRden(symIndexHash(k,l))
               if(m.ne.n.and.mod(flag,100)/10.eq.1) then
                 if(abs(abHHCden(symIndexHash(m,n))).gt.zero) &
-                  abHHCfoc(symIndexHash(k,l)) = abHHCfoc(symIndexHash(k,l)) - &
+                  abHHCfoc(symIndexHash(k,l)) = abHHCfoc(symIndexHash(k,l)) + &
                   raf3*abHHCden(symIndexHash(m,n))
                 if(abs(abHHCden(symIndexHash(k,l))).gt.zero) &
-                  abHHCfoc(symIndexHash(m,n)) = abHHCfoc(symIndexHash(m,n)) - &
+                  abHHCfoc(symIndexHash(m,n)) = abHHCfoc(symIndexHash(m,n)) + &
                   raf3*abHHCden(symIndexHash(k,l))
               endIf
 !         AB Antihermitian Hermitian Fock
               if(m.ne.n.and.abs(abAHRden(symIndexHash(m,n))).gt.zero) &
-                abAHRfoc(symIndexHash(k,l)) = abAHRfoc(symIndexHash(k,l)) - &
+                abAHRfoc(symIndexHash(k,l)) = abAHRfoc(symIndexHash(k,l)) + &
                 raf3*abAHRden(symIndexHash(m,n))
               if(m.ne.n.and.abs(abAHRden(symIndexHash(k,l))).gt.zero) &
-                abAHRfoc(symIndexHash(m,n)) = abAHRfoc(symIndexHash(m,n)) - &
+                abAHRfoc(symIndexHash(m,n)) = abAHRfoc(symIndexHash(m,n)) + &
                 raf3*abAHRden(symIndexHash(k,l))
               if (mod(flag,100)/10.eq.1) then
                 if(abs(abAHCden(symIndexHash(m,n))).gt.zero) &
@@ -7554,10 +7556,10 @@
 !         AA Antihermitian Fock
           if(doAhrm) then
             if(m.ne.n.and.abs(aaARden(symIndexHash(m,n))).gt.zero) &
-              aaARfoc(symIndexHash(k,l)) = aaARfoc(symIndexHash(k,l)) - &
+              aaARfoc(symIndexHash(k,l)) = aaARfoc(symIndexHash(k,l)) + &
               raf3*aaARden(symIndexHash(m,n))
             if(m.ne.n.and.abs(aaARden(symIndexHash(k,l))).gt.zero) &
-              aaARfoc(symIndexHash(m,n)) = aaARfoc(symIndexHash(m,n)) - &
+              aaARfoc(symIndexHash(m,n)) = aaARfoc(symIndexHash(m,n)) + &
               raf3*aaARden(symIndexHash(k,l))
             if(mod(flag,100)/10.eq.1) then
               if(abs(aaACden(symIndexHash(m,n))).gt.zero) &
@@ -7570,10 +7572,10 @@
             if(mod(flag,10).gt.0) then
 !         BB Antihermitian Fock
               if(m.ne.n.and.abs(bbARden(symIndexHash(m,n))).gt.zero) &
-                bbARfoc(symIndexHash(k,l)) = bbARfoc(symIndexHash(k,l)) - &
+                bbARfoc(symIndexHash(k,l)) = bbARfoc(symIndexHash(k,l)) + &
                 raf3*bbARden(symIndexHash(m,n))
               if(m.ne.n.and.abs(bbARden(symIndexHash(k,l))).gt.zero) &
-                bbARfoc(symIndexHash(m,n)) = bbARfoc(symIndexHash(m,n)) - &
+                bbARfoc(symIndexHash(m,n)) = bbARfoc(symIndexHash(m,n)) + &
                 raf3*bbARden(symIndexHash(k,l))
               if(mod(flag,100)/10.eq.1) then
                 if(abs(bbACden(symIndexHash(m,n))).gt.zero) &
@@ -7594,18 +7596,18 @@
                 raf2*abHARden(symIndexHash(k,l))
               if(mod(flag,100)/10.eq.1.and.m.ne.n) then
                 if(abs(abHACden(symIndexHash(m,n))).gt.zero) &
-                 abHACfoc(symIndexHash(k,l)) = abHACfoc(symIndexHash(k,l)) - &
+                 abHACfoc(symIndexHash(k,l)) = abHACfoc(symIndexHash(k,l)) + &
                  raf3*abHACden(symIndexHash(m,n))
                 if(abs(abHACden(symIndexHash(k,l))).gt.zero) &
-                 abHACfoc(symIndexHash(m,n)) = abHACfoc(symIndexHash(m,n)) - &
+                 abHACfoc(symIndexHash(m,n)) = abHACfoc(symIndexHash(m,n)) + &
                  raf3*abHACden(symIndexHash(k,l))
              endIf
 !         AB Antihermitian Antihermitian Fock
               if(m.ne.n.and.abs(abAARden(symIndexHash(m,n))).gt.zero) &
-                abAARfoc(symIndexHash(k,l)) = abAARfoc(symIndexHash(k,l)) - &
+                abAARfoc(symIndexHash(k,l)) = abAARfoc(symIndexHash(k,l)) + &
                 raf3*abAARden(symIndexHash(m,n))
               if(m.ne.n.and.abs(abAARden(symIndexHash(k,l))).gt.zero) &
-                abAARfoc(symIndexHash(m,n)) = abAARfoc(symIndexHash(m,n)) - &
+                abAARfoc(symIndexHash(m,n)) = abAARfoc(symIndexHash(m,n)) + &
                 raf3*abAARden(symIndexHash(k,l))
               if(mod(flag,100)/10.eq.1) then
                 if(abs(abAACden(symIndexHash(m,n))).gt.zero) &

--- a/src/mqc_est.F03
+++ b/src/mqc_est.F03
@@ -2119,7 +2119,7 @@
 !     PROCEDURE MQC_Matrix_To_Integral
 !
 !>    \brief <b> MQC_Matrix_To_Integral is used to transform MQC_Matrix objects into
-!>    MQC_SCF_Integral objects
+!>    MQC_SCF_Integral objects</b>
 !
 !>    \par Purpose:
 !     =============

--- a/src/mqc_gaussian.f03
+++ b/src/mqc_gaussian.f03
@@ -860,7 +860,7 @@
 !
 !     Local temp variables.
       character(len=256)::my_filename
-      logical::DEBUG=.true.,ok
+      logical::DEBUG=.true.,ok,openbool
 !
 !
 !     Format statements.
@@ -891,6 +891,8 @@
           fileinfo%filename=trim(filename)
         endIf
       endIf
+      inquire(file=fileinfo%filename,number=fileinfo%unitNumber,opened=openbool)
+      if(openbool) close(fileInfo%unitNumber)
 !
 !     Check if all the required information is in fileinfo, and if no then
 !     initialize it.


### PR DESCRIPTION
- Raf3 integrals obtained by transformation of regular integrals had opposite sign to Gaussian Raf3 integrals. Updated transformation code and integral contraction code to follow Gaussians sign convention for Raf3 integrals.
- Threshold for zero has been updated in psuedoinverse code. Now it uses the size of the largest singular value, the machine epsilon, and the matrix dimension to determine zero.
- Updated the write header code to close and reopen file if requested file name has already been opened under a different unit number. This error occurred if overwriting a matrix file with new data that had already been opened to retrieve data.